### PR TITLE
Add babylon-walk import to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ In the following example, we are trying to count the number of functions in the 
 ```js
 import * as t from 'babel-types';
 import {parse} from 'babylon';
+import * as walk from 'babylon-walk';
 
 const visitors = {
   Statement(node, state, c) {


### PR DESCRIPTION
It's just a minor thing, but the example in the README doesn't work "as is" because it doesn't import `walk.recursive`. Added the import to the top.